### PR TITLE
SeatGeek: Improvements

### DIFF
--- a/lib/DDG/Spice/SeatGeek/EventsByArtist.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsByArtist.pm
@@ -2,6 +2,7 @@ package DDG::Spice::SeatGeek::EventsByArtist;
 # ABSTRACT: Returns upcoming concerts for a band/artist.
 
 use DDG::Spice;
+use Text::Trim;
 
 primary_example_queries "live show weezer", "upcoming concerts bjork";
 description "Upcoming concerts from SeatGeek";
@@ -12,7 +13,8 @@ topics "entertainment", "music";
 attribution github => ['https://github.com/MariagraziaAlastra','MariagraziaAlastra'],
     github => ['https://github.com/andrey-p','Andrey Pissantchev'];
 
-triggers startend => 'upcoming concert',
+triggers startend => 
+    'upcoming concert',
     'upcoming concerts',
     'concert',
     'concerts',
@@ -25,17 +27,13 @@ spice proxy_cache_valid => "200 304 12h";
 
 spice to => 'http://api.seatgeek.com/2/events?taxonomies.name=concert&performers.slug=$1&callback={{callback}}';
 
-handle remainder_lc => sub {
-    # Removes triggers from the query
-    $_ =~ s/^(:?(upcoming\s*)?(concerts?))|((live)\s*(:?(shows?))?)|(gigs)$//gi;
-
+handle remainder_lc => sub {  
     # If query starts with any of these assume it's one of the other queries
     return if ($_ =~ /^(in |at |near me)/);
 
-    # Removes spaces from the beginning of the query
-    $_ =~ s/^\s+//;
-    # Removes spaces from the end of the query
-    $_ =~ s/\s+$//;
+    # Removes spaces from the start and beginning of the query
+    $_ = trim($_);
+
     # Replaces spaces between words with dashes, because the API requires it
     $_ =~ s/\s/\-/g;
     return $_ if $_;

--- a/lib/DDG/Spice/SeatGeek/EventsByCity.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsByCity.pm
@@ -12,7 +12,9 @@ topics "entertainment", "music";
 attribution github => ['https://github.com/MariagraziaAlastra','MariagraziaAlastra'],
     github => ['https://github.com/andrey-p','Andrey Pissantchev'];
 
-triggers start => 'upcoming concerts in',
+triggers start => 
+    'upcoming concert in',
+    'upcoming concerts in',
     'concerts in',
     'live in',
     'live shows in',

--- a/lib/DDG/Spice/SeatGeek/EventsByVenue.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsByVenue.pm
@@ -12,7 +12,9 @@ topics "entertainment", "music";
 attribution github => ['https://github.com/MariagraziaAlastra','MariagraziaAlastra'],
     github => ['https://github.com/andrey-p','Andrey Pissantchev'];
 
-triggers start => 'upcoming concerts at',
+triggers start => 
+    'upcoming concert at',
+    'upcoming concerts at',
     'concerts at',
     'live at',
     'live shows at',

--- a/lib/DDG/Spice/SeatGeek/EventsNearMe.pm
+++ b/lib/DDG/Spice/SeatGeek/EventsNearMe.pm
@@ -12,7 +12,9 @@ topics "entertainment", "music";
 attribution github => ['https://github.com/MariagraziaAlastra','MariagraziaAlastra'],
     github => ['https://github.com/andrey-p','Andrey Pissantchev'];
 
-triggers start => 'upcoming concerts',
+triggers start => 
+    'upcoming concert',
+    'upcoming concerts',
     'concerts',
     'live',
     'live shows',

--- a/share/spice/seat_geek/events_by_artist/seat_geek_events_by_artist.js
+++ b/share/spice/seat_geek/events_by_artist/seat_geek_events_by_artist.js
@@ -6,11 +6,14 @@
             return Spice.failed('seat_geek_events_by_artist');
         }
 
-        var query = DDG.get_query(),
-            artistName = query.replace(/((upcoming\s)?(concerts?))|(live(\s(shows?))?)|(gigs)/, '').trim(),
-            months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'],
-            days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+         // Get the original query.
+        var script = $('[src*="/js/spice/seat_geek/events_by_artist/"]')[0],
+            source = $(script).attr("src"),
+            artistName = source.match(/events_by_artist\/([^\/]*)/)[1];
 
+        var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'],
+            days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+            
         Spice.add({
             id: "seat_geek_events_by_artist",
             name: "Concerts",


### PR DESCRIPTION
Hey @andrey-p noticed some potential improvements to SeatGeek code.

Changes:
- Match "concert" and "concerts"
- No need to replace triggers in EventsByArtist.pm as using `remainder_lc` line 30 **(need to add additional keywords to triggers=>, "live, shows, gigs")**
- Remove unneeded `replace()` of trigger words in _seat_geek_events_by_artist.js_, get artistName: `[src*="/js/spice/seat_geek/events_by_artist/"]`
- Use `trim()` function to remove leading & trailing spaces

Feel free to discuss any changes I've made here before merging :+1: 

PR: #1429
